### PR TITLE
OPE-705: ckeditor shouldn't crash if one of the plugins is missing;

### DIFF
--- a/core/resourcemanager.js
+++ b/core/resourcemanager.js
@@ -215,7 +215,9 @@ CKEDITOR.resourceManager.prototype = {
 
 		CKEDITOR.scriptLoader.load( urls, function( completed, failed ) {
 			if ( failed.length ) {
-				throw new Error( '[CKEDITOR.resourceManager.load] Resource name "' + urlsNames[ failed[ 0 ] ].join( ',' ) +
+				// throw new Error( '[CKEDITOR.resourceManager.load] Resource name "' + urlsNames[ failed[ 0 ] ].join( ',' ) +
+				// 	'" was not found at "' + failed[ 0 ] + '".' );
+				console.error( '[CKEDITOR.resourceManager.load] Resource name "' + urlsNames[ failed[ 0 ] ].join( ',' ) +
 					'" was not found at "' + failed[ 0 ] + '".' );
 			}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sr/ckeditor4",
-  "version": "4.23.0",
+  "version": "4.23.1",
   "description": "The development version of CKEditor - JavaScript WYSIWYG web text editor.",
   "author": "CKSource (https://cksource.com/)",
   "license": "(GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1-or-later)",


### PR DESCRIPTION
I would like to add a few small changes to ensure that ckeditor instances don't crash if there is a mismatch between richtexteditor or any components relying on specific plugins (there have been problems a few times). Reasons for the change:

1. I don't believe it makes sense to throw errors when trying to add a plugin which doesn't exist, for whatever reason. If I have 10 other perfectly working plugins then fine, I don't want the 11th one to crash the whole instance;
2. ckeditr doesn't seem to provide a clean API that would allow to cleanly detect which plugins are available. I already looked through their source code, even with the help of Copilot, and tried a few things which were ugly and bug-prone unfortunately;
3. Also this seems like the easiest option to fix potential future problems without digging deeper or doing major architectural changes in the ckeditor/richTextEditor realm;
4. There was a high bug and an RCA as a result (you can see the ticket if interested);

https://smartrecruiters.atlassian.net/jira/software/c/projects/OPE/boards/529?selectedIssue=OPE-705&useStoredSettings=true

Showing how the instance crashes if the plugin is not available in the old version vs how it still works and simply informs of an error using console.error():

https://github.com/user-attachments/assets/efdba889-169f-4b92-add8-d60dc7306973

